### PR TITLE
Added CLI argument support

### DIFF
--- a/ACMOS.pyw
+++ b/ACMOS.pyw
@@ -10,7 +10,7 @@ from tkinter import ttk
 from tkinter import messagebox
 from tkinter.filedialog import askdirectory
 from os import listdir, makedirs, remove, strerror
-from os.path import exists, isdir, join, split
+from os.path import exists, isdir, join, split, abspath
 from shutil import make_archive, move
 from glob import glob, escape
 from subprocess import check_call, CalledProcessError
@@ -381,14 +381,14 @@ if __name__ == '__main__':
     if out_path_arg == None:
         out_path_arg = text['btn_output_path'][language.get()]
     else:
-        out_path_arg = out_path_arg[3:].strip('"\'')
+        out_path_arg = abspath(out_path_arg[3:].strip('"\''))
 
     #Get CLI argument for LOD path
     lod_path_arg = next((s for s in sys.argv if s.startswith("-l:")), None)
     if lod_path_arg == None:
         lod_path_arg = text['btn_lod_path'][language.get()]
     else:
-        lod_path_arg = lod_path_arg[3:].strip('"\'')
+        lod_path_arg = abspath(lod_path_arg[3:].strip('"\''))
 
     #Road selection dropdown
     lbl_roads_label = tk.Label(frame_roads, text=text['lbl_roads_label'][language.get()])

--- a/ACMOS.pyw
+++ b/ACMOS.pyw
@@ -193,7 +193,7 @@ def read_texconv(input_file):
 
 def generate(worldspaces, road_path, output_path, lod_path, texconv):
     #Clear output directory, if argument is given
-    if '-clear-output-on-generate' in sys.argv:
+    if '-clear-output-on-generate' in sys.argv and exists(output_path):
         rmtree(output_path)
 
     #Generate roads

--- a/ACMOS.pyw
+++ b/ACMOS.pyw
@@ -244,7 +244,17 @@ def generate(worldspaces, road_path, output_path, lod_path, texconv):
             except OSError as ex:
                 sm(f'Error: OSError removing {file}: {ex}')
     sm(text['Zip contents prompt title'][language.get()])
-    answer = messagebox.askyesno(text['Zip contents prompt title'][language.get()],text['Zip contents prompt message'][language.get()])
+    
+    if '-zip' in sys.argv:
+        #If -zip argument is provided, zip output
+        answer = True
+    else:
+        if '-autorun' in sys.argv:
+            answer = False #Autorunning and no -zip argument provided. Don't zip
+        else:
+            #Not autorunning, ask the user
+            answer = messagebox.askyesno(text['Zip contents prompt title'][language.get()],text['Zip contents prompt message'][language.get()])
+    
     if answer:
         sm(f'Please wait... This could take a while... Zipping {output_path} to {output_path}\\Terrain LOD.zip')
         make_archive('Terrain LOD', 'zip', output_path)
@@ -324,7 +334,10 @@ def generate_button():
         #send all done message
         sm(message)
         btn_generate['text'] = text['btn_generate'][language.get()]
-        messagebox.showinfo(message, message)
+
+        #Show all done message, if not auto-running.
+        if '-autorun' not in sys.argv:
+            messagebox.showinfo(message, message)
         btn_generate['state'] = 'normal'
     else:
         sm(text['Invalid LOD path message'][language.get()])

--- a/ACMOS.pyw
+++ b/ACMOS.pyw
@@ -11,7 +11,7 @@ from tkinter import messagebox
 from tkinter.filedialog import askdirectory
 from os import listdir, makedirs, remove, strerror
 from os.path import exists, isdir, join, split, abspath
-from shutil import make_archive, move
+from shutil import make_archive, move, rmtree
 from glob import glob, escape
 from subprocess import check_call, CalledProcessError
 from datetime import datetime
@@ -192,6 +192,10 @@ def read_texconv(input_file):
         sm("Error: " + str(ex), 1)
 
 def generate(worldspaces, road_path, output_path, lod_path, texconv):
+    #Clear output directory, if argument is given
+    if '-clear-output-on-generate' in sys.argv:
+        rmtree(output_path)
+
     #Generate roads
     world_dict = {}
     progress_bar.start()

--- a/ACMOS.pyw
+++ b/ACMOS.pyw
@@ -1,5 +1,6 @@
 '''ACMOS Road Generator'''
 
+import sys
 import tkinter as tk
 import json
 import logging
@@ -375,25 +376,50 @@ if __name__ == '__main__':
     optm_language = ttk.OptionMenu(window, language, text['languages'][0], *text['languages'], command=change_language)
     optm_language.pack(padx=5, pady=5)
 
+    #Get CLI argument for output path
+    out_path_arg = next((s for s in sys.argv if s.startswith("-o:")), None)
+    if out_path_arg == None:
+        out_path_arg = text['btn_output_path'][language.get()]
+    else:
+        out_path_arg = out_path_arg[3:].strip('"\'')
+
+    #Get CLI argument for LOD path
+    lod_path_arg = next((s for s in sys.argv if s.startswith("-l:")), None)
+    if lod_path_arg == None:
+        lod_path_arg = text['btn_lod_path'][language.get()]
+    else:
+        lod_path_arg = lod_path_arg[3:].strip('"\'')
+
     #Road selection dropdown
     lbl_roads_label = tk.Label(frame_roads, text=text['lbl_roads_label'][language.get()])
     lbl_roads_label.pack(anchor=tk.NW, padx=5, pady=10, side=tk.LEFT)
     road_dirs = listdir(f'roads')
+    
+    #Get CLI argument for road selection
+    type_arg = next((s for s in sys.argv if s.startswith("-t:")), None)
+
+    if type_arg != None:
+        type_arg = type_arg[3:].strip('"\'')
+        if road_dirs.index(type_arg) > -1:
+            selected_roads = type_arg
+    else:
+        selected_roads = road_dirs[0]
+
     road_selection = tk.StringVar(window)
     road_selection.set(road_dirs[0])
-    optm_roads = ttk.OptionMenu(frame_roads, road_selection, road_dirs[0], *road_dirs)
+    optm_roads = ttk.OptionMenu(frame_roads, road_selection, selected_roads, *road_dirs)
     optm_roads.pack(anchor=tk.NW, padx=5, pady=9)
-
+    
     #LOD Path widgets
     lbl_lod_path_label = tk.Label(frame_lod, text=text['lbl_lod_path_label'][language.get()])
     lbl_lod_path_label.pack(anchor=tk.NW, padx=5, pady=15, side=tk.LEFT)
-    btn_lod_path = tk.Button(frame_lod, text=text['btn_lod_path'][language.get()], command=set_lod_path)
+    btn_lod_path = tk.Button(frame_lod, text=lod_path_arg, command=set_lod_path)
     btn_lod_path.pack(anchor=tk.NW, padx=5, pady=10)
     
     #Output Path widgets
     lbl_output_path_label = tk.Label(frame_output, text=text['lbl_output_path_label'][language.get()])
     lbl_output_path_label.pack(anchor=tk.NW, padx=5, pady=15, side=tk.LEFT)
-    btn_output_path = tk.Button(frame_output, text=text['btn_output_path'][language.get()], command=set_output_path)
+    btn_output_path = tk.Button(frame_output, text=out_path_arg, command=set_output_path)
     btn_output_path.pack(anchor=tk.NW, padx=5, pady=10)
     
     #Generate button
@@ -414,5 +440,9 @@ if __name__ == '__main__':
     frame_output.pack()
     frame_generate.pack(expand=True, fill=tk.X)
     
-    #Start app
-    window.mainloop()
+    #Get autorun CLI argument
+    if '-autorun' in sys.argv:
+        generate_button()
+    else:
+        #Start app
+        window.mainloop()

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The follwing CLI arguments are available.
 
 | Parameter                  | Description                                                                  | Example                                                          |
 |----------------------------|------------------------------------------------------------------------------|------------------------------------------------------------------|
+| -zip                       | Zips the output. If not using this or `-autorun`, you will be prompted.      | `-zip`                                                           |
 | -l                         | LOD Path. Relative paths are supported.                                      | `-l:"C:\Path to LOD\xLODGen Output"` or `-l:"./xLODGen Output"`  |
 | -o                         | Output Path. Relative paths are supported.                                   | `-o:"C:\Skyrim Modding\ACMOS Output"` or `-o:"./ACMOS Output"`   |
 | -t                         | Roads Type                                                                   | `-t:"Roads"` or `-t:"Paths Only"`                                |

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Requires Python 3 with Pillow. I use version 3.8 to compile to ensure compatibil
 
 Also requires texconv.exe from DirectXTex: https://github.com/microsoft/DirectXTex. It should be placed in subfolder called texconv, or modify code to point to your custom path.
 
-# CLI arguments
+## CLI arguments
 The follwing CLI arguments are available.
 
 | -l       | LOD Path                                           | `-l:"C:\Path to LOD\xLODGen Output"`  |

--- a/README.md
+++ b/README.md
@@ -5,4 +5,13 @@ Requires Python 3 with Pillow. I use version 3.8 to compile to ensure compatibil
 
 Also requires texconv.exe from DirectXTex: https://github.com/microsoft/DirectXTex. It should be placed in subfolder called texconv, or modify code to point to your custom path.
 
+# CLI arguments
+The follwing CLI arguments are available.
+
+| -l       | LOD Path                                           | `-l:"C:\Path to LOD\xLODGen Output"`  |
+|----------|----------------------------------------------------|---------------------------------------|
+| -o       | Output Path                                        | `-o:"C:\Skyrim Modding\ACMOS Output"` |
+| -t       | Roads Type                                         | `-t:"Roads"` or `-t:"Paths Only"`     |
+| -autorun | Automatically clicks the "Generate" button for you | `-autorun`                            |
+
 CC BY-NC-SA

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Also requires texconv.exe from DirectXTex: https://github.com/microsoft/DirectXT
 ## CLI arguments
 The follwing CLI arguments are available.
 
-| Parameter | Description                                        | Example                               |
-|-----------|----------------------------------------------------|---------------------------------------|
-| -l        | LOD Path                                           | `-l:"C:\Path to LOD\xLODGen Output"`  |
-| -o        | Output Path                                        | `-o:"C:\Skyrim Modding\ACMOS Output"` |
-| -t        | Roads Type                                         | `-t:"Roads"` or `-t:"Paths Only"`     |
-| -autorun  | Automatically clicks the "Generate" button for you | `-autorun`                            |
+| Parameter | Description                                        | Example                                                          |
+|-----------|----------------------------------------------------|------------------------------------------------------------------|
+| -l        | LOD Path. Relative paths are supported.            | `-l:"C:\Path to LOD\xLODGen Output"` or `-l:"./xLODGen Output"`  |
+| -o        | Output Path. Relative paths are supported.         | `-o:"C:\Skyrim Modding\ACMOS Output"` or `-o:"./ACMOS Output"`   |
+| -t        | Roads Type                                         | `-t:"Roads"` or `-t:"Paths Only"`                                |
+| -autorun  | Automatically clicks the "Generate" button for you | `-autorun`                                                       |
 
 CC BY-NC-SA

--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@ Also requires texconv.exe from DirectXTex: https://github.com/microsoft/DirectXT
 ## CLI arguments
 The follwing CLI arguments are available.
 
-| Parameter | Description                                        | Example                                                          |
-|-----------|----------------------------------------------------|------------------------------------------------------------------|
-| -l        | LOD Path. Relative paths are supported.            | `-l:"C:\Path to LOD\xLODGen Output"` or `-l:"./xLODGen Output"`  |
-| -o        | Output Path. Relative paths are supported.         | `-o:"C:\Skyrim Modding\ACMOS Output"` or `-o:"./ACMOS Output"`   |
-| -t        | Roads Type                                         | `-t:"Roads"` or `-t:"Paths Only"`                                |
-| -autorun  | Automatically clicks the "Generate" button for you | `-autorun`                                                       |
+| Parameter                  | Description                                                                  | Example                                                          |
+|----------------------------|------------------------------------------------------------------------------|------------------------------------------------------------------|
+| -l                         | LOD Path. Relative paths are supported.                                      | `-l:"C:\Path to LOD\xLODGen Output"` or `-l:"./xLODGen Output"`  |
+| -o                         | Output Path. Relative paths are supported.                                   | `-o:"C:\Skyrim Modding\ACMOS Output"` or `-o:"./ACMOS Output"`   |
+| -t                         | Roads Type                                                                   | `-t:"Roads"` or `-t:"Paths Only"`                                |
+| -autorun                   | Automatically clicks the "Generate" button for you.                          | `-autorun`                                                       |
+| -clear-output-on-generate  | ***Deletes*** the folder selected as Output Path, upon starting generation.  | `-clear-output-on-generate`                                      |
 
 CC BY-NC-SA

--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ Also requires texconv.exe from DirectXTex: https://github.com/microsoft/DirectXT
 ## CLI arguments
 The follwing CLI arguments are available.
 
-| -l       | LOD Path                                           | `-l:"C:\Path to LOD\xLODGen Output"`  |
-|----------|----------------------------------------------------|---------------------------------------|
-| -o       | Output Path                                        | `-o:"C:\Skyrim Modding\ACMOS Output"` |
-| -t       | Roads Type                                         | `-t:"Roads"` or `-t:"Paths Only"`     |
-| -autorun | Automatically clicks the "Generate" button for you | `-autorun`                            |
+| Parameter | Description                                        | Example                               |
+|-----------|----------------------------------------------------|---------------------------------------|
+| -l        | LOD Path                                           | `-l:"C:\Path to LOD\xLODGen Output"`  |
+| -o        | Output Path                                        | `-o:"C:\Skyrim Modding\ACMOS Output"` |
+| -t        | Roads Type                                         | `-t:"Roads"` or `-t:"Paths Only"`     |
+| -autorun  | Automatically clicks the "Generate" button for you | `-autorun`                            |
 
 CC BY-NC-SA


### PR DESCRIPTION
I added support for setting the LOD path, output path and road type using commandline arguments.  
The arguments also include an `-autorun` parameter, to automatically start the generation, and a `-clear-output-on-generate` parameter. The path arguments support both absolute and relative paths.  
All the parameters are documented in the [README.md](https://github.com/MaverickMartyn/ACMOS-Road-Generator/blob/master/README.md) file.

This is useful for launching from mod managers. I for one, use my own build with a portable Mod Organizer 2 instance.  
That way, I don't need to remember or even update the paths. All it takes to update the roads is executing the shortcut, if you point the output to a mod folder.

Here's is an example of how I use it: `ACMOS Road Generator.exe -autorun -clear-output-on-generate -l:"../xLODGen/xLODGen_Output" -o:"../ACMOS_Output"`.

Maybe there's a better name for the `-clear-output-on-generate` argument, since it's a tad long.