### PR TITLE
Remember last user inputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ Build with pyinstaller.bat
 build/
 dist/
 texconv/*
+config.ini
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs


### PR DESCRIPTION
Language, type of roads generation, LOD and Output paths are stored in config.ini file. So they are used as default values, when the program is restarted.

This is achieved by the Python in-built configparser module.

This is intended mainly for keeping language selection, but I extended it to every user-input value of the GUI.

The config.ini save happens after clicking "Generate" to minimize the code edit impact, maybe it could be a better solution.